### PR TITLE
[feature] add a support for mapState with nested modules

### DIFF
--- a/src/assets/template/optionsAPI.txt
+++ b/src/assets/template/optionsAPI.txt
@@ -31,8 +31,8 @@ export default Vue.extend({
     }
   },
   computed: {
-    ...mapGetters('module1', ['getter1']),
-    ...mapState('module2', ['state1']),
+    ...mapGetters('module1/module2', ['getter1']),
+    ...mapState('module3/module4', ['state1']),
     doubledNum(): number {
       return this.numData * 2
     },
@@ -77,7 +77,7 @@ export default Vue.extend({
     console.log('destroyed')
   },
   methods: {
-    ...mapActions('module3', ['action1']),
+    ...mapActions('module5/module6', ['action1']),
     increment():number {
       return this.numData++
     },

--- a/src/lib/converters/options/computedConverter.ts
+++ b/src/lib/converters/options/computedConverter.ts
@@ -31,7 +31,10 @@ export const computedConverter = (
             return names.map(({ text: name }) => {
               return {
                 use: "computed",
-                expression: `const ${name} = computed(() => ${storePath}.state.${namespaceText}.${name})`,
+                expression: `const ${name} = computed(() => ${storePath}.state.${namespaceText.replaceAll(
+                  "/",
+                  "."
+                )}.${name})`,
                 returnNames: [name],
               };
             });


### PR DESCRIPTION
`mapState` is not converted correctly when the namespace is nested so I fixed it.

Source:
<img width="275" alt="スクリーンショット 2022-05-23 13 10 21" src="https://user-images.githubusercontent.com/34234442/169741696-85fe786f-c29b-4f89-b3c0-84f04f02052d.png">

Result:
<img width="475" alt="スクリーンショット 2022-05-23 13 04 48" src="https://user-images.githubusercontent.com/34234442/169741244-2542dd0e-93a9-478b-9b00-5521dc96c432.png">
