### PR TITLE
ts.createPrinter().printFile の結果に Unicode 文字を含む場合は unescape する

### DIFF
--- a/src/lib/converters/classApiConverter.ts
+++ b/src/lib/converters/classApiConverter.ts
@@ -4,6 +4,7 @@ import {
   getExportStatement,
   getImportStatement,
   lifecycleNameMap,
+  containUnicodeChar,
 } from "../helper";
 import { convertOptions } from "./options/optionsConverter";
 
@@ -141,7 +142,11 @@ export const convertClass = (
     sourceFile.flags
   );
   const printer = ts.createPrinter();
-  return printer.printFile(newSrc);
+  const content = printer.printFile(newSrc);
+
+  return containUnicodeChar(content)
+    ? unescape(content.replace(/\\u/g, "%u"))
+    : content;
 };
 
 const parseClassNode = (

--- a/src/lib/converters/optionsApiConverter.ts
+++ b/src/lib/converters/optionsApiConverter.ts
@@ -1,5 +1,9 @@
 import ts from "typescript";
-import { getExportStatement, getImportStatement } from "../helper";
+import {
+  getExportStatement,
+  getImportStatement,
+  containUnicodeChar,
+} from "../helper";
 import { convertOptions } from "./options/optionsConverter";
 
 export const convertOptionsApi = (sourceFile: ts.SourceFile) => {
@@ -20,5 +24,9 @@ export const convertOptionsApi = (sourceFile: ts.SourceFile) => {
     sourceFile.flags
   );
   const printer = ts.createPrinter();
-  return printer.printFile(newSrc);
+  const content = printer.printFile(newSrc);
+
+  return containUnicodeChar(content)
+    ? unescape(content.replace(/\\u/g, "%u"))
+    : content;
 };

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -221,3 +221,7 @@ export const getSetupStatements = (setupProps: ConvertedExpression[]) => {
     )
     .flat();
 };
+
+export const containUnicodeChar = (str: string) => {
+  return /\\u.{4}/gi.test(str);
+};


### PR DESCRIPTION
resolve: https://github.com/miyaoka/vue-composition-converter/issues/8

## 解決したいこと
非アスキー文字の場合コンバート結果が escape されて文字化けしてしまうため、
Unicode 文字の場合は unescape するようにしたい

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/26811986/194743360-8bb5e149-0b6c-48a3-a613-73f836e58cc3.png">


## 参考
ref: https://github.com/microsoft/TypeScript/issues/36174#issuecomment-597564149